### PR TITLE
Harden GitHub Actions: pin actions to SHAs and set explicit permissions

### DIFF
--- a/.github/workflows/add-to-priority-tracker.yml
+++ b/.github/workflows/add-to-priority-tracker.yml
@@ -4,12 +4,15 @@ on:
   issues:
     types: [opened, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project-and-labels:
     runs-on: ubuntu-latest
     steps:
       - name: Add labels if missing and then add to Priority Tracker project
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.ORG_PROJECT_TOKEN }}
           script: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci_lint_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/golangci-lint.yml@main

--- a/.github/workflows/registry-publish.yml
+++ b/.github/workflows/registry-publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   registry_publish_workflow_ghcr:
     uses: turbot/steampipe-workflows/.github/workflows/registry-publish-ghcr.yml@main

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/stale.yml@main

--- a/.github/workflows/steampipe-anywhere.yml
+++ b/.github/workflows/steampipe-anywhere.yml
@@ -6,6 +6,9 @@ on:
       - 'v*'
         
 
+permissions:
+  contents: write
+
 jobs:
   anywhere_publish_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/steampipe-anywhere.yml@main

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -4,6 +4,10 @@ on:
     - cron: "30 22 * * 1"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   sync_labels_workflow:
     uses: turbot/steampipe-workflows/.github/workflows/sync-labels.yml@main


### PR DESCRIPTION
## Harden GitHub Actions workflows

- Pin all action/workflow references to immutable commit SHAs
- Add explicit minimal `permissions` blocks

**Why**: Prevents supply chain attacks where a tag could be moved to point to malicious code. Explicit permissions reduce blast radius if a workflow is compromised.